### PR TITLE
Develop/updated link path periods

### DIFF
--- a/assets/script.js
+++ b/assets/script.js
@@ -17,3 +17,24 @@ function getApi(requestUrl) {
 }
 
 getApi(requestUrl);
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/index.html
+++ b/index.html
@@ -5,19 +5,19 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-Zenh87qX5JnK2Jl0vWa8Ck2rdkQ2Bzep5IDxbcnCeuOxjzrPF/et3URy9Bv1WTRi" crossorigin="anonymous">
-  <link rel="stylesheet" href="/assets/reset.css">
-  <link rel="stylesheet" href="/assets/style.css">
+  <link rel="stylesheet" href="./assets/reset.css">
+  <link rel="stylesheet" href="./assets/style.css">
   <title>Project Camp</title>
 </head>
 <body>
-  <header id="response-text">testing</header>
-  
-  
+  <h1>Project-Camp</h1>
+  <h2 id="response-text">Campsite API Query Content</h2>
+  <p>query data example</p>   
   <script
       src="https://code.jquery.com/jquery-3.5.1.min.js"
       integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0="
       crossorigin="anonymous"
     ></script>
-  <script src="/assets/script.js"></script>
+  <script src="./assets/script.js"></script>
 </body>
 </html>


### PR DESCRIPTION
During the start of my JavaScript testing...I noticed that the file paths of the links/script items of the index.html file were missing their starting period characters for the home/starting directory.